### PR TITLE
Add wantsNewState() to AnyStoreSubscriber protocol

### DIFF
--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -9,6 +9,13 @@
 public protocol AnyStoreSubscriber: AnyObject {
     // swiftlint:disable:next identifier_name
     func _newState(state: Any)
+
+    /// Subscribers may indicate if they require a state update for the provided action. 
+    func wantsNewState(_ action: Action) -> Bool
+}
+
+extension AnyStoreSubscriber {
+  public func wantsNewState(_ action: Action) -> Bool { return true }
 }
 
 public protocol StoreSubscriber: AnyStoreSubscriber {


### PR DESCRIPTION
- Subscribers who return false will not incur the costs of comparing states, nor receive a `newState()` call
- I initially started with a category system within ReSwift, but opted for this more flexible approach so clients can determine how they filter state updates